### PR TITLE
Fix compilation errors for MXAO and SMAA related to CEIL_DIV

### DIFF
--- a/Shaders/MartysMods_MXAO.fx
+++ b/Shaders/MartysMods_MXAO.fx
@@ -185,6 +185,8 @@ sampler sAOTex2 { Texture = AOTex2; };
 
 //#undef _COMPUTE_SUPPORTED
 
+#define CEIL_DIV(num, denom) ((((num) - 1) / (denom)) + 1)
+
 #if ((BUFFER_WIDTH/4)*4) == BUFFER_WIDTH
  #define DEINTERLEAVE_HIGH       0
  #define DEINTERLEAVE_TILE_COUNT 4u

--- a/Shaders/MartysMods_SMAA.fx
+++ b/Shaders/MartysMods_SMAA.fx
@@ -176,6 +176,8 @@ texture ColorInputTex : COLOR;
 texture DepthInputTex : DEPTH;
 sampler DepthInput  { Texture = DepthInputTex; };
 
+#define CEIL_DIV(num, denom) (((num - 1) / denom) + 1)
+
 #include ".\MartysMods\mmx_global.fxh"
 #include ".\MartysMods\mmx_depth.fxh"
 #include ".\MartysMods\mmx_math.fxh"


### PR DESCRIPTION
This allows MXAO and SMAA shaders to compile without issue in recent versions of Reshade 6.3.x